### PR TITLE
Fixes error on ehr endpoint

### DIFF
--- a/src/main/java/org/bih/eos/converter/composition/CompositionToMDConverter.java
+++ b/src/main/java/org/bih/eos/converter/composition/CompositionToMDConverter.java
@@ -59,7 +59,7 @@ public class CompositionToMDConverter extends CompositionToEntityConverter<CDTCo
 		//First try to generate the visitOccurrence from sourceId, and if that fails, just get a default one
 		Optional<VisitOccurrence> visitOccurrence;
 		Optional<Composition> optionalComposition=Optional.of(convertableComposition.getComposition());
-		Optional<EHRToPerson> optionalEhrToPerson=Optional.of(convertableComposition.getEhrToPerson());
+		Optional<EHRToPerson> optionalEhrToPerson=Optional.ofNullable(convertableComposition.getEhrToPerson());
 		visitOccurrence=getVisitFromSourceId(optionalComposition,optionalEhrToPerson);
 		if(visitOccurrence.isEmpty())
 		{


### PR DESCRIPTION
For calls of ehr when no visit generation has been done prior we need the EHRToVisit to be nullable. This fixes issue detected by @prabash
