### PR TITLE
changes to docker compose file in the setup

### DIFF
--- a/setup/compose.yaml
+++ b/setup/compose.yaml
@@ -4,7 +4,6 @@ services:
     profiles:
       - cdm
     image: cdm_db:latest
-    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile
@@ -42,7 +41,6 @@ services:
       EOS_OPENEHR_SECURITY_TYPE: BASIC
       EOS_OPENEHR_SECURITY_USER_NAME: myuser
       EOS_OPENEHR_SECURITY_USER_PASSWORD: myPassword432
-    platform: linux/amd64
     networks:
       - ehrbase-net
       - eos-net
@@ -58,7 +56,6 @@ services:
     profiles:
       - ehrbase
     image: ehrbase/ehrbase:next
-    platform: linux/amd64
     ports:
       - 8080:8080
     networks:
@@ -83,7 +80,6 @@ services:
     profiles:
       - ehrbase
     image: ehrbase/ehrbase-postgres:latest
-    platform: linux/amd64
     ports:
       - 5433:5432
     networks:

--- a/setup/compose.yaml
+++ b/setup/compose.yaml
@@ -4,6 +4,7 @@ services:
     profiles:
       - cdm
     image: cdm_db:latest
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile
@@ -30,10 +31,18 @@ services:
     image: ghcr.io/sevkohler/eos:latest
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://cdm-db:5432/postgres
+      # Spring JPA Properties
+      SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA: public
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      # EOS Custom Properties
+      EOS_CDM_DATABASE_NAME: postgres
+      EOS_CDM_SCHEMA: public
+      # EOS OpenEHR Properties
       EOS_OPENEHR_BASE_URL: http://ehrbase:8080/ehrbase/
       EOS_OPENEHR_SECURITY_TYPE: BASIC
       EOS_OPENEHR_SECURITY_USER_NAME: myuser
       EOS_OPENEHR_SECURITY_USER_PASSWORD: myPassword432
+    platform: linux/amd64
     networks:
       - ehrbase-net
       - eos-net
@@ -49,6 +58,7 @@ services:
     profiles:
       - ehrbase
     image: ehrbase/ehrbase:next
+    platform: linux/amd64
     ports:
       - 8080:8080
     networks:
@@ -73,6 +83,7 @@ services:
     profiles:
       - ehrbase
     image: ehrbase/ehrbase-postgres:latest
+    platform: linux/amd64
     ports:
       - 5433:5432
     networks:


### PR DESCRIPTION
changed the setup docker compose file to support additional configurations for the eos container  and explicit platform support for all containers to support macos. We faced some issues when trying to connect to a different database/schema due to these configs lacking the docker compose file, which we fixed locally; but I thought it would be beneficial to have these configs by default on the docker compose file for the future.